### PR TITLE
deleted the bad marker

### DIFF
--- a/app/assets/javascripts/controller.js
+++ b/app/assets/javascripts/controller.js
@@ -25,7 +25,7 @@ SoapStone.Controller.prototype.createDrop = function(form) {
     drop.marker = new google.maps.Marker({
       map: self.mapView.map,
       position: new google.maps.LatLng(drop.lat, drop.lon),
-      animation: google.maps.Animation.DROP,
+      // animation: google.maps.Animation.DROP,
       icon: {
         path: google.maps.SymbolPath.BACKWARD_CLOSED_ARROW,
         scale: 6,

--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -55,8 +55,11 @@ Array.prototype.updateDropsArray = function (func, oldArray, otherArray, limit){
       }
     var outIndex =  $.inArray(dropData.id, otherArray.map(function(obj){return obj.id}));
     if (outIndex != -1){//it was outside but now inside so remove that from the old outside
+      var kill = oldArray[outIndex];
+      kill.marker.setMap(null);//not needed but take it off the map before destorying incase of ZOMBIE points
+      delete kill; 
       oldArray.splice(outIndex,1);
+
     }
   })
 }
-


### PR DESCRIPTION
The bug is when pins change type from being inside to outside and previos version of the marker doesnt get deleted but rather gets drawn over(saw this when my gps randomly changed location otherwise I wouldnt have noticed). I tried to fix this in the helper method by both setting the changing marker's map to null to remove it off the map and then also I deleted the obj itself (double tap) :gun: :gun: 

the other bug was for some UNKNOWN REASON if you make a new drop and then YOU DONT REFRESH the page whenever you go into a drop view and then press the 'x' button it would then redrop that marker onto the map. I had no idea why it was doing this (why wouldnt it drop jake bot again he has the drop animation too) but to deal with this I took out the drop animation completely so that the point just appears so whatever the error was is now hidden (not MVP fix maybe) :sleepy: 

edit: another bug...... every 5 seconds when the timer hits and it redraws the menu next to the map it scrolls you back up to the top no matter where you are which is annoying and shitty UX :bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug::bug:

sorry i snuck bugs into master.

love ninja saboteur/team lead -
jake
